### PR TITLE
Fix animation state maintenance after completion

### DIFF
--- a/src/Frontend.elm
+++ b/src/Frontend.elm
@@ -230,18 +230,15 @@ updateFromBackend msg model =
 
                 Nothing ->
                     ( { model
-                        | fGame = fGame
-                        , maybeName =
+                        | maybeName =
                             case model.maybeName of
                                 Just _ ->
                                     model.maybeName
 
                                 Nothing ->
                                     getMyName model.sessionId fGame
-                        , gameDisposition = Calculated <| calculateGameDisposition model.viewPort (fPlayersFromFGame fGame |> getOpponents model.sessionId) (getOwnedCards fGame)
-                        , alreadyInAction = False
                       }
-                    , Cmd.none
+                    , Delay.after (round animDuration) (UpdateFGamePostAnimationFrontend fGame NoPlayerAction)
                     )
 
         UpdateGameAndChatToFrontend ( fGame, chat ) ->

--- a/src/Positioning/Animate.elm
+++ b/src/Positioning/Animate.elm
@@ -508,6 +508,8 @@ animatePlayerAction playerAction newGameDisposition fModel =
                                             |> Timeline.to (Anim.ms animDuration) positions.discardPilePosition
                                 }
                     }
+                NoPlayerAction ->
+                    fModel
 
         _ ->
             fModel

--- a/src/Types.elm
+++ b/src/Types.elm
@@ -231,6 +231,7 @@ type PlayerActionAnimation
     | AnimationDoubleCardFailed SessionId Int Card
     | AnimationSwitchCards ( SessionId, Int ) ( SessionId, Int )
     | AnimationDiscardCard
+    | NoPlayerAction
 
 
 type alias PositionedPlayer =


### PR DESCRIPTION
Related to #16

Introduces a delay mechanism for game state updates without player actions and adds a new variant to handle cases with no player action.

- Adds a new variant `NoPlayerAction` to the `PlayerActionAnimation` type in `src/Types.elm` to handle scenarios where there is no player action.
- Modifies the `updateFromBackend` function in `src/Frontend.elm` to introduce a delay even when there is no `playerAction`, ensuring the game state does not revert to the last state immediately after an animation. This is achieved by using the newly added `NoPlayerAction` variant.
- Ensures that `fGame` and `gameDisposition` are not updated immediately if there is no `playerAction`, preventing premature state reversion and maintaining the new state post-animation.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/CharlonTank/tamalou-v2/issues/16?shareId=14b5965f-aa6e-420d-87c9-2ebc603146bb).