### PR TITLE
Add variant for displaying tamalou failure

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -6,3 +6,7 @@
 	path = elm-animator
 	url = https://github.com/mdgriffith/elm-animator.git
 	branch = v2
+[submodule "elm-ui15:49:52"]
+	path = elm-ui15:49:52
+	url = https://github.com/mdgriffith/elm-ui.git
+	branch = 2.0

--- a/elm-ui15:49:52/.gitignore
+++ b/elm-ui15:49:52/.gitignore
@@ -1,0 +1,32 @@
+# elm-package generated files
+elm-stuff/
+# elm-repl generated files
+repl-temp-*
+.DS_Store
+*/index.html
+index.html
+.elm-static-html
+
+tests/html-generation/rendered/
+
+env
+elm.js
+
+examples/temporary/
+
+.vscode
+
+
+sauce.env
+
+__pycache__
+node_modules
+benchmarks/tmp
+benchmarks/results
+tests/tmp
+
+tmp
+
+stylesheets/generated/dev*
+
+temp-animator

--- a/elm-ui15:49:52/LICENSE
+++ b/elm-ui15:49:52/LICENSE
@@ -1,0 +1,27 @@
+Copyright (c) 2020, Matthew Griffith
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+* Neither the name of Elm UI nor the names of its
+  contributors may be used to endorse or promote products derived from
+  this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/elm-ui15:49:52/benchmarks/micro/Suite.elm
+++ b/elm-ui15:49:52/benchmarks/micro/Suite.elm
@@ -1,0 +1,433 @@
+module Suite exposing (main)
+
+import Benchmark exposing (Benchmark)
+import Benchmark.Runner exposing (BenchmarkProgram, program)
+import Dict
+import Element exposing (..)
+import Element.Background as Background
+import Element.Font as Font
+import Html
+import Html.Attributes
+import Internal.Flag as Flag
+import Internal.Model as Internal
+import Json.Encode
+import Set
+
+
+dict : Benchmark
+dict =
+    let
+        dest =
+            Dict.singleton "a" 1
+    in
+    Benchmark.describe "dictionary"
+        [ Benchmark.benchmark "get" (\_ -> Dict.get "a" dest)
+        , Benchmark.benchmark "insert" (\_ -> Dict.insert "b" 2 dest)
+        ]
+
+
+main : BenchmarkProgram
+main =
+    program <|
+        Benchmark.describe "sample"
+            [ --dict
+              -- , deduplications
+              --   renderPipeline
+              gatheringAttributes
+            , lotsOfElements
+
+            --   flagOperations
+            ]
+
+
+flagOperations =
+    Benchmark.describe "Flag Operations"
+        [ Benchmark.benchmark "check if present" <|
+            \_ ->
+                Flag.present Flag.height Flag.none
+        , Benchmark.benchmark "add to flag" <|
+            \_ ->
+                Flag.add Flag.height Flag.none
+        ]
+
+
+basics =
+    Benchmark.describe "Basics"
+        [ Benchmark.benchmark "String Concatenation" <|
+            \_ ->
+                "This"
+                    ++ "this"
+                    ++ "this"
+                    ++ "this"
+                    ++ "this"
+                    ++ "this"
+                    ++ "this"
+                    ++ "this"
+        , Benchmark.benchmark "List String Concatenation" <|
+            \_ ->
+                String.concat
+                    [ "This"
+                    , "this"
+                    , "this"
+                    , "this"
+                    , "this"
+                    , "this"
+                    , "this"
+                    , "this"
+                    ]
+        , Benchmark.benchmark "Simple list filterMap" <|
+            \_ ->
+                List.filterMap
+                    identity
+                    [ Just "thing"
+                    , Just "other width"
+                    ]
+        , Benchmark.benchmark "Simple list map" <|
+            \_ ->
+                List.map
+                    identity
+                    [ Just "thing"
+                    , Just "other width"
+                    ]
+        ]
+
+
+recurseVsFoldl =
+    Benchmark.describe "Recurse vs Foldl"
+        [ Benchmark.benchmark "Foldl base speed" <|
+            \_ ->
+                List.foldl
+                    (::)
+                    [ Just "thing"
+                    , Just "other width"
+                    ]
+        , Benchmark.benchmark "Recursive" <|
+            \_ ->
+                recurse
+                    (::)
+                    [ Just "thing"
+                    , Just "other width"
+                    ]
+        ]
+
+
+oneThousand =
+    List.repeat 1000 (el [] (text "hello"))
+
+
+lotsOfElements =
+    Benchmark.describe "Lots of Children"
+        [ Benchmark.benchmark "1000 Row" <|
+            \_ ->
+                Element.row []
+                    (List.repeat 1000 (el [] (text "hello")))
+        , Benchmark.benchmark "Baseline 1000 - " <|
+            \_ ->
+                List.repeat 1000 (el [] (text "hello"))
+        , Benchmark.benchmark "1000 Row -  Overhead" <|
+            \_ ->
+                Element.row []
+                    oneThousand
+        , Benchmark.benchmark "1000 Div" <|
+            \_ ->
+                Html.div []
+                    (List.repeat 1000 (Html.div [] [ Html.text "hello" ]))
+        ]
+
+
+gatheringAttributes =
+    Benchmark.describe "Gather Attributes"
+        [ Benchmark.benchmark "Existing - gatherAttrRecursive" <|
+            \_ ->
+                Internal.gatherAttrRecursive
+                    (Internal.contextClasses Internal.AsEl)
+                    Internal.Generic
+                    Flag.none
+                    Internal.Untransformed
+                    []
+                    []
+                    Internal.NoNearbyChildren
+                    [ Element.width Element.shrink
+                    , Element.height Element.shrink
+                    ]
+        , Benchmark.benchmark "Mocked - foldl - new record each iteration" <|
+            \_ ->
+                List.foldl flipFoldl
+                    { attributes = "class"
+                    , styles = []
+                    , node = "Node"
+                    , children = Nothing
+                    , has = Flag.none
+                    }
+                    -- we reverse first because we have to for the attr api.
+                    (List.reverse
+                        [ Just "thing"
+                        , Just "other width"
+                        ]
+                    )
+        , Benchmark.benchmark "Mocked - foldl - update" <|
+            \_ ->
+                List.foldl flipFoldlUpdate
+                    { attributes = "class"
+                    , styles = []
+                    , node = "Node"
+                    , children = Nothing
+                    , has = Flag.none
+                    }
+                    -- we reverse first because we have to for the attr api.
+                    (List.reverse
+                        [ Just "thing"
+                        , Just "other width"
+                        ]
+                    )
+        , Benchmark.benchmark "Mocked - recurse - new record each iteration" <|
+            \_ ->
+                recurseGather
+                    -- we reverse first because we have to for the attr api.
+                    (List.reverse
+                        [ Just "thing"
+                        , Just "other width"
+                        ]
+                    )
+                    { attributes = "class"
+                    , styles = []
+                    , node = "Node"
+                    , children = Nothing
+                    , has = Flag.none
+                    }
+        , Benchmark.benchmark "Mocked - recurse - update" <|
+            \_ ->
+                recurseGatherUpdate
+                    -- we reverse first because we have to for the attr api.
+                    (List.reverse
+                        [ Just "thing"
+                        , Just "other width"
+                        ]
+                    )
+                    { attributes = "class"
+                    , styles = []
+                    , node = "Node"
+                    , children = Nothing
+                    , has = Flag.none
+                    }
+        ]
+
+
+recurseGather remaining found =
+    case remaining of
+        [] ->
+            { attributes = "class" ++ found.attributes
+            , styles = Just 1 :: found.styles
+            , node = found.node
+            , children = Nothing
+            , has = Flag.add Flag.height found.has
+            }
+
+        fst :: rem ->
+            recurseGather rem
+                { attributes = "class" ++ found.attributes
+                , styles = Just 1 :: found.styles
+                , node = found.node
+                , children = Nothing
+                , has = Flag.add Flag.height found.has
+                }
+
+
+recurseGatherUpdate remaining found =
+    case remaining of
+        [] ->
+            { found
+                | attributes = "class" ++ found.attributes
+                , styles = Just 1 :: found.styles
+                , has = Flag.add Flag.height found.has
+            }
+
+        fst :: rem ->
+            recurseGatherUpdate rem
+                { found
+                    | attributes = "class" ++ found.attributes
+                    , styles = Just 1 :: found.styles
+                    , has = Flag.add Flag.height found.has
+                }
+
+
+flipFoldl result found =
+    { attributes = "class" ++ found.attributes
+    , styles = Just 1 :: found.styles
+    , node = found.node
+    , children = Nothing
+    , has = Flag.add Flag.height found.has
+    }
+
+
+flipFoldlUpdate result found =
+    { found
+        | attributes = "class" ++ found.attributes
+        , styles = Just 1 :: found.styles
+        , has = Flag.add Flag.height found.has
+    }
+
+
+recurse fn ls =
+    case ls of
+        [] ->
+            []
+
+        fst :: remain ->
+            fn fst (recurse fn remain)
+
+
+deduplications =
+    Benchmark.describe "deduplications"
+        [ Benchmark.benchmark "fold - dedup, String concat"
+            (\_ ->
+                String.join ":" (foldDedup largeList)
+            )
+        , Benchmark.benchmark "fold - dedup"
+            (\_ ->
+                foldDedup largeList
+            )
+        , Benchmark.benchmark "fold - dedup - Int"
+            (\_ ->
+                foldDedup largeListInt
+            )
+        , Benchmark.benchmark "Json encode"
+            (\_ ->
+                Json.Encode.object largeListJson
+            )
+        ]
+
+
+foldDedup list =
+    let
+        dedup ( name, val ) ( cache, ls ) =
+            if Set.member name cache then
+                ( cache, ls )
+
+            else
+                ( Set.insert name cache, val :: ls )
+    in
+    List.foldl dedup ( Set.empty, [] ) list
+        |> Tuple.second
+
+
+largeListInt =
+    List.range 1 10000
+        |> List.map
+            (\i ->
+                let
+                    wrappingI =
+                        modBy 50 i
+                in
+                ( wrappingI, "elem-" ++ String.fromInt wrappingI )
+            )
+
+
+largeList =
+    List.range 1 10000
+        |> List.map
+            (\i ->
+                let
+                    wrappingI =
+                        modBy 50 i
+                in
+                ( "elem-" ++ String.fromInt wrappingI, "elem-" ++ String.fromInt wrappingI )
+            )
+
+
+largeListJson =
+    List.range 1 10000
+        |> List.map
+            (\i ->
+                let
+                    wrappingI =
+                        modBy 50 i
+                in
+                ( "elem-" ++ String.fromInt wrappingI, Json.Encode.string ("elem-" ++ String.fromInt wrappingI) )
+            )
+
+
+renderPipeline =
+    [ Benchmark.benchmark "build 2000 elements"
+        (\_ ->
+            elements 0 twoThousand
+        )
+    , Benchmark.benchmark "build 2000 html"
+        (\_ ->
+            html 0 twoThousand
+        )
+    ]
+
+
+twoThousand =
+    List.range 0 2000
+
+
+elements i count =
+    Element.layout []
+        (Element.column [ spacing 8, centerX ]
+            (List.map (viewEl i) count)
+        )
+
+
+viewEl selectedIndex index =
+    el
+        [ Background.color
+            (if selectedIndex == index then
+                pink
+
+             else
+                white
+            )
+        , Font.color
+            (if selectedIndex /= index then
+                pink
+
+             else
+                white
+            )
+        , padding 24
+        , width (px 500)
+        , height (px 70)
+        ]
+        (if selectedIndex == index then
+            text "selected"
+
+         else
+            text "Hello!"
+        )
+
+
+white =
+    rgb 1 1 1
+
+
+pink =
+    rgb255 240 0 245
+
+
+html i count =
+    Html.div []
+        [ Html.div []
+            (List.map (viewHtmlElement i) count)
+        ]
+
+
+viewHtmlElement selectedIndex index =
+    Html.div
+        [ Html.Attributes.class
+            (if selectedIndex == index then
+                "white"
+
+             else
+                "pink"
+            )
+        ]
+        [ Html.div []
+            [ if selectedIndex == index then
+                Html.text "selected"
+
+              else
+                Html.text "Hello!"
+            ]
+        ]

--- a/elm-ui15:49:52/benchmarks/runtime/benchPage.js
+++ b/elm-ui15:49:52/benchmarks/runtime/benchPage.js
@@ -1,0 +1,146 @@
+const path = require('path');
+
+async function benchPage(page, file) {
+    const client = await page.target().createCDPSession();
+    await client.send('Performance.enable');
+    // await page.tracing.start({ path: 'trace.json' });
+    await page.goto('file://' + path.resolve(file))
+
+    await page.waitFor(5000);
+    // await page.tracing.stop();
+    const metrics = await client.send('Performance.getMetrics');
+
+    const startMetrics = await page.metrics()
+    await page.evaluate(() => { window.elmRefresh() })
+    await page.waitFor(1500);
+    const endMetrics = await page.metrics()
+
+    await page.evaluate(() => { window.elmStartAnim() })
+    await sleep(5000)
+    await page.evaluate(() => { window.elmStopAnim() })
+    await page.waitFor(2000);
+    const finalMetrics = await page.metrics()
+    const frames = await page.evaluate(x => {
+        return Promise.resolve(window.metrics);
+    }, {});
+    return {
+        name: frames.name,
+        link: 'file://' + path.resolve(file),
+        perf: extract(metrics),
+        afterRefresh: {
+            RecalcStyleDuration: endMetrics.RecalcStyleDuration - startMetrics.RecalcStyleDuration,
+            LayoutDuration: endMetrics.LayoutDuration - startMetrics.LayoutDuration,
+            ScriptDuration: endMetrics.ScriptDuration - startMetrics.ScriptDuration,
+            JSHeapUsedSize: endMetrics.JSHeapUsedSize - startMetrics.JSHeapUsedSize
+        },
+        afterAnimation: {
+            RecalcStyleDuration: finalMetrics.RecalcStyleDuration - endMetrics.RecalcStyleDuration,
+            LayoutDuration: finalMetrics.LayoutDuration - endMetrics.LayoutDuration,
+            ScriptDuration: finalMetrics.ScriptDuration - endMetrics.ScriptDuration,
+            JSHeapUsedSize: finalMetrics.JSHeapUsedSize - endMetrics.JSHeapUsedSize
+        },
+        frames: summarize(frames.frames),
+    }
+}
+
+function summarize(frames) {
+    return {
+        count: frames.length,
+        median: median(frames),
+        mode: mode(frames),
+        avg: average(frames),
+        fps: 1000 / median(frames),
+        min: minimum(frames),
+        max: maximum(frames)
+    }
+}
+
+const keep = ["Timestamp", "Nodes", "LayoutDuration", "RecalcStyleDuration", "ScriptDuration", "JSHeapUsedSize", "FirstMeaningfulPaint", "DomContentLoaded", "NavigationStart"]
+
+
+function extract(metrics) {
+    var ext = {}
+    metrics.metrics.forEach((item) => {
+        if (keep.indexOf(item.name) >= 0) {
+            ext[item.name] = item.value
+        }
+    })
+    ext.TimeToFirstPaintMS = 1000 * (ext.FirstMeaningfulPaint - ext.DomContentLoaded)
+    return ext
+}
+
+function mode(array) {
+    if (array.length == 0)
+        return null;
+    var modeMap = {};
+    var maxEl = array[0], maxCount = 1;
+    for (var i = 0; i < array.length; i++) {
+        var el = array[i];
+        if (modeMap[el] == null)
+            modeMap[el] = 1;
+        else
+            modeMap[el]++;
+        if (modeMap[el] > maxCount) {
+            maxEl = el;
+            maxCount = modeMap[el];
+        }
+    }
+    return maxEl;
+}
+
+function minimum(values) {
+    var m = null
+    for (var i = 0; i < values.length; i++) {
+        if (m == null) {
+            m = values[i]
+        } else if (values[i] < m) {
+            m = values[i]
+        }
+    }
+    return m
+}
+
+
+function maximum(values) {
+    var m = null
+    for (var i = 0; i < values.length; i++) {
+        if (m == null) {
+            m = values[i]
+        } else if (values[i] > m) {
+            m = values[i]
+        }
+    }
+    return m
+}
+
+
+function average(values) {
+    var total = 0;
+    for (var i = 0; i < values.length; i++) {
+        total += values[i];
+    }
+    return total / values.length;
+}
+
+function median(values) {
+    if (values.length === 0) return 0;
+
+    values.sort(function (a, b) {
+        return a - b;
+    });
+
+    var half = Math.floor(values.length / 2);
+
+    if (values.length % 2)
+        return values[half];
+
+    return (values[half - 1] + values[half]) / 2.0;
+}
+
+
+function sleep(ms) {
+    return new Promise(resolve => {
+        setTimeout(resolve, ms)
+    })
+}
+module.exports = benchPage;

--- a/elm-ui15:49:52/benchmarks/src/ElmUITwo.elm
+++ b/elm-ui15:49:52/benchmarks/src/ElmUITwo.elm
@@ -1,0 +1,163 @@
+module ElmUITwo exposing
+    ( elmUITwo1024
+    , elmUITwo128
+    , elmUITwo2048
+    , elmUITwo24
+    , elmUITwo256
+    , elmUITwo4096
+    , elmUITwo512
+    , elmUITwo64
+    , elmUITwo8192
+    )
+
+{-| -}
+
+import Benchmark.Render
+import Element2 as Two
+import Element2.Background as Background2
+import Element2.Font as Font2
+import Html
+import Html.Attributes
+
+
+
+{- START BENCHMARKS -}
+{- Elm UI 2.0 -}
+
+
+elmUITwo24 : Benchmark.Render.Benchmark Model Msg
+elmUITwo24 =
+    elmUITwo "elmUITwo24" 24
+
+
+elmUITwo64 : Benchmark.Render.Benchmark Model Msg
+elmUITwo64 =
+    elmUITwo "elmUITwo64" 64
+
+
+elmUITwo128 : Benchmark.Render.Benchmark Model Msg
+elmUITwo128 =
+    elmUITwo "elmUITwo128" 128
+
+
+elmUITwo256 : Benchmark.Render.Benchmark Model Msg
+elmUITwo256 =
+    elmUITwo "elmUITwo256" 256
+
+
+elmUITwo512 : Benchmark.Render.Benchmark Model Msg
+elmUITwo512 =
+    elmUITwo "elmUITwo512" 512
+
+
+elmUITwo1024 : Benchmark.Render.Benchmark Model Msg
+elmUITwo1024 =
+    elmUITwo "elmUITwo1024" 1024
+
+
+elmUITwo2048 : Benchmark.Render.Benchmark Model Msg
+elmUITwo2048 =
+    elmUITwo "elmUITwo2048" 2048
+
+
+elmUITwo4096 : Benchmark.Render.Benchmark Model Msg
+elmUITwo4096 =
+    elmUITwo "elmUITwo4096" 4096
+
+
+elmUITwo8192 : Benchmark.Render.Benchmark Model Msg
+elmUITwo8192 =
+    elmUITwo "elmUITwo8192" 8192
+
+
+
+{- END BENCHMARKS -}
+
+
+type alias Model =
+    { index : Int
+    , numberOfElements : Int
+    , elements : List Int
+    }
+
+
+type Msg
+    = Refresh
+    | Tick Float
+
+
+{-| -}
+elmUITwo : String -> Int -> Benchmark.Render.Benchmark Model Msg
+elmUITwo name count =
+    { name = name
+    , init =
+        { index = 0
+        , numberOfElements = count
+        , elements = List.range 0 (count - 1)
+        }
+    , view =
+        \model ->
+            Two.layout []
+                (Two.column
+                    [ Two.spacing 8
+                    , Two.centerX
+                    ]
+                    (List.map (viewElTwo model.index) model.elements)
+                )
+    , update =
+        \msg model ->
+            case msg of
+                Refresh ->
+                    if model.index > model.numberOfElements then
+                        { model | index = 0 }
+
+                    else
+                        { model | index = model.index + 1 }
+
+                Tick i ->
+                    if model.index > model.numberOfElements then
+                        { model | index = 0 }
+
+                    else
+                        { model | index = model.index + 1 }
+    , tick = Tick
+    , refresh = Refresh
+    }
+
+
+viewElTwo selectedIndex index =
+    Two.el
+        [ Background2.color
+            (if selectedIndex == index then
+                pinkTwo
+
+             else
+                whiteTwo
+            )
+        , Font2.color
+            (if selectedIndex /= index then
+                pinkTwo
+
+             else
+                whiteTwo
+            )
+        , Two.padding 24
+        , Two.width (Two.px 500)
+
+        -- , Two.width (Two.fillPortion ((selectedIndex |> modBy 2) + 1))
+        , Two.height (Two.px 70)
+        ]
+        (if selectedIndex == index then
+            Two.text "selected"
+
+         else
+            Two.text "Hello!"
+        )
+
+
+whiteTwo =
+    Two.rgb 255 255 255
+
+
+pinkTwo =
+    Two.rgb 240 0 245

--- a/elm-ui15:49:52/experiments/font-adjustment-updated/FontAdjustment2Center.elm
+++ b/elm-ui15:49:52/experiments/font-adjustment-updated/FontAdjustment2Center.elm
@@ -1,0 +1,473 @@
+module FontAdjustment2Center exposing (main)
+
+{-| Line Height as its specified through CSS doesn't make a whole lot of sense typographically.
+
+We also run into issues with sizing a font. The font size generally refers to the full type size (from the top of ascendors to the bottom of descenders)
+
+However, sometimes we might want to size things from the top of the Capital to the baseline.
+
+Or from the top of the x-height to the baseline.
+
+The main place this shows up is for dropped capitals, and for text on buttons.
+
+-}
+
+import Browser
+import Element exposing (..)
+import Element.Background as Background
+import Element.Border as Border
+import Element.Font as Font
+import Element.Input as Input
+import Element.Lazy
+import Html
+import Html.Attributes
+
+
+type alias FontAdjustment =
+    { offset : Float
+    , height : Float
+    }
+
+
+type alias Line =
+    Float
+
+
+type Msg
+    = UpdateAdjustment FontAdjustment
+
+
+edges =
+    { top = 0
+    , right = 0
+    , bottom = 0
+    , left = 0
+    }
+
+reset = 
+    { offset = 0
+    , height = 1
+
+    }
+
+
+garamond =
+    let
+        default =
+             { offset = 0
+            , height = 1
+
+            }
+    in
+    { adjustment =
+        default
+    , converted =
+        convertAdjustment default
+    , font =
+        { url = Just "https://fonts.googleapis.com/css?family=EB+Garamond"
+        , name = "EB Garamond"
+        , variants = []
+        , adjustment =
+            default
+        }
+    }
+
+
+catamaran =
+    let
+        default =
+             { offset = 0
+                , height = 1
+
+            }
+    in
+    { adjustment =
+        default
+    , converted =
+        convertAdjustment default
+    , font =
+        { url = Just "https://fonts.googleapis.com/css?family=Catamaran"
+        , name = "Catamaran"
+        , variants = []
+        , adjustment =
+           default
+        }
+    }
+
+
+poiret =
+    let
+        default =
+             { offset = 0
+                , height = 1
+
+                }
+    in
+    { adjustment =
+        default
+    , converted =
+        convertAdjustment default
+    , font =
+        { url = Just "https://fonts.googleapis.com/css?family=Poiret+One"
+        , name = "Poiret One"
+        , variants = []
+        , adjustment =
+            default
+        }
+    }
+
+
+roboto =
+    let
+        default =
+             { offset = 0
+                , height = 1
+
+                }
+    in
+    { adjustment =
+        default
+    , converted =
+        convertAdjustment default
+    , font =
+        { url = Just "https://fonts.googleapis.com/css?family=Roboto"
+        , name = "Roboto"
+        , adjustment =
+           default
+        , variants = []
+        }
+    }
+
+
+init =
+    -- catamaran
+    garamond
+
+
+
+-- poiret
+-- roboto
+
+
+update msg model =
+    case msg of
+        UpdateAdjustment adj ->
+            let
+                font =
+                    model.font
+            in
+            { model
+                | adjustment = adj
+                , converted = convertAdjustment adj
+                , font =
+                    { font
+                        | adjustment =
+                            adj
+                    }
+            }
+
+
+main =
+    Browser.sandbox
+        { init = init
+        , update = update
+        , view = view
+        }
+
+
+view model =
+    Element.layout
+        [ above (html (Html.node "style" [] [ Html.text """
+.lh-15 .t {
+   line-height: 1.5;
+}
+
+.lh-norm .t {
+    line-height: normal;
+}
+          
+             """ ]))
+        , Background.color (rgba 1 1 1 1)
+        , padding 100
+        , Font.color (rgba 0 0 0 1)
+        , Font.family
+            [ -- Font.external
+              -- { url = "https://fonts.googleapis.com/css?family=EB+Garamond"
+              -- , name = "EB Garamond"
+              -- }
+              --   Font.external
+              --     { url = "https://fonts.googleapis.com/css?family=Catamaran"
+              --     , name = "Catamaran"
+              --     }
+            --   Font.with
+            --     { name = model.font.name
+            --     , adjustment = Just model.font.adjustment
+            --     , variants = model.font.variants
+            --     }
+
+            -- model.font
+            -- , 
+            Font.sansSerif
+            ]
+        ]
+    <|
+        column [ width fill, height fill, spacing 128 ]
+            [ adjustor 120 model.adjustment
+            , adjusted 120 model.converted
+            ]
+
+
+style name val =
+    htmlAttribute (Html.Attributes.style name val)
+
+
+class name =
+    htmlAttribute (Html.Attributes.class name)
+
+
+charcoal =
+    rgb 0.7 0.7 0.7
+
+
+adjustor size adjustment =
+    let
+        labels =
+            [ viewAdjustment "Offset" adjustment.offset 180  
+                -1 0
+                (\offset -> { adjustment | offset = offset })
+            , viewAdjustment "Height" adjustment.height 50 
+                0
+                1
+                (\height -> { adjustment | height = height })
+            ]
+    in
+    el
+        ([ centerX
+         , centerY
+         , Background.color (rgb 0 0.8 0.9)
+         , inFront
+            (el
+                [ height (px (round (toFloat size *  adjustment.height)))
+                , width (px 800)
+                , moveRight 10
+                -- , alignBottom
+                , moveUp (toFloat size * adjustment.offset)
+                , Border.color (rgb 0 0 0)
+                , Border.dashed
+                , Border.widthEach
+                    { top = 1
+                    , right = 0
+                    , bottom = 1
+                    , left = 0
+                    }
+                ]
+                none
+            )
+        
+         , style "line-height" "1"
+         , Font.size size
+         ]
+            ++ labels
+        )
+        (text "Typography")
+
+
+adjusted size adjustment =
+    column
+        [ spacing 48
+        , centerX
+        , centerY
+        ]
+        [ el
+            [ Font.size 32 ]
+            (text "New Adjustments in Els")
+        , row
+            [ Font.size 85
+            , padding 80
+            , spacing 48
+            ]
+            [ el
+                [ Font.size 95
+                , Font.full
+                , Background.color (rgb 0 0.8 0.9)
+                , above (el [ Font.size 24, moveUp 6 ] (text "full height"))
+                , onLeft <|
+                    el
+                        [ centerY
+                        , width (px 40)
+                        , height (px 95)
+                        , Background.color (rgb 0.9 0.8 0)
+                        ]
+                        none
+                ]
+                (text "Typography")
+            , el
+                [ Font.sizeByCapital
+                , Font.size 85
+                , Background.color (rgb 0 0.8 0.9)
+                , above (el [ Font.size 24, moveUp 6 ] (text "corrected capital"))
+                , onLeft <|
+                    el
+                        [ centerY
+                        , width (px 40)
+                        , height (px 85)
+                        , Background.color (rgb 0.9 0.8 0)
+                        ]
+                        none
+                ]
+                (text "Typography")
+            ]
+        , el [ Font.size 32 ] (text "Standard Defaults in CSS")
+        , row
+            [ spacing 32
+            , Font.size 120
+            ]
+            [ el
+                [ Background.color (rgb 0 0.8 0.9)
+                , style "line-height" "normal"
+                , class "lh-norm"
+                , above (el [ Font.size 12 ] (text "line-height: normal"))
+                ]
+                (text "Typography")
+            , el
+                [ Background.color (rgb 0 0.8 0.9)
+                , style "line-height" "1"
+                , above (el [ Font.size 12 ] (text "line-height: 1"))
+                ]
+                (text "Typography")
+            ]
+        , row [ spacing 120 ]
+            [ paragraph
+                [ Font.size 25
+                , spacing 5
+                , width (px 200)
+                , Background.color
+                    (rgb 0 0.8 0.9)
+                , above (el [ Font.size 32, moveUp 32 ] (text "Normal Paragraphs"))
+                ]
+                [ el [ Font.size 55, alignLeft, Background.color (rgb 0.9 0.8 0) ] (text "L")
+                , text "orem Ipsum is simply dummy text of the printing and typesetting industry."
+                ]
+            , paragraph
+                [ Font.size 25
+                , spacing 10
+                , width (px 600)
+                , inFront
+                    (el
+                        [ width (px 100)
+                        , height (px 5)
+                        , moveDown 45
+                        , alignRight
+                        , Background.color (rgba 0.9 0.8 0.2 0.5)
+                        ]
+                        none
+                    )
+                , inFront
+                    (el
+                        [ width (px 100)
+                        , height (px 45)
+                        , alignRight
+                        , Background.color (rgba 0 0 0 0.5)
+                        ]
+                        none
+                    )
+                , Background.color
+                    (rgb 0 0.8 0.9)
+                , above
+                    (el [ Font.size 32, moveUp 32 ] (text "Corrected Paragraphs"))
+                ]
+                [ el
+                    [ Font.size 100
+                    , alignLeft
+                    , Background.color (rgb 0.9 0.8 0)
+                    , Font.sizeByCapital
+                    ]
+                    (text "C")
+                , text "ontrary to popular belief, Lorem Ipsum is not simply random text. It has roots in a piece of classical Latin literature from 45 BC, making it over 2000 years old. Richard McClintock, a Latin professor at Hampden-Sydney College in Virginia, looked up one of the more obscure Latin words, consectetur, from a Lorem Ipsum passage, and going through the cites of the word in classical literature, discovered the undoubtable source. Lorem Ipsum comes from sections 1.10.32 and 1.10.33 of \"de Finibus Bonorum et Malorum\" (The Extremes of Good and Evil) by Cicero, written in 45 BC. This book is a treatise on the theory of ethics, very popular during the Renaissance. The first line of Lorem Ipsum, \"Lorem ipsum dolor sit amet..\", comes from a line in section 1.10.32."
+                ]
+            ]
+        ]
+
+
+corrected converted label =
+    el
+        [ Background.color (rgb 0 0.8 0.9)
+        , style "display" "block"
+        , above (el [ Font.size 12, moveUp 6 ] (text label))
+        , style "line-height" (String.fromFloat converted.height)
+        , below
+            (column [ Font.size 12, spacing 5, moveDown 10 ]
+                [ text ("height: " ++ String.left 5 (String.fromFloat converted.height))
+                , text ("vertical: " ++ String.left 5 (String.fromFloat converted.vertical))
+                ]
+            )
+        ]
+        (el
+            [ style "display" "inline-block"
+            , style "line-height" (String.fromFloat converted.height)
+            , style "vertical-align" (String.fromFloat converted.vertical ++ "em")
+            ]
+            (text "Typography")
+        )
+
+
+
+type alias Details =  
+    { offset : Float
+    , height : Float
+    
+
+    }
+
+convertAdjustment : FontAdjustment -> Details
+convertAdjustment adjustment =
+    adjustment
+
+
+viewAdjustment label adjustment left minVal maxVal updateWith =
+  
+    onLeft
+        (el
+            [ moveLeft left
+            , height fill
+            ]
+         <|
+            Input.slider
+                [ Font.size 24
+                , Element.behindContent
+                    (Element.el
+                        [ Element.width (Element.px 1)
+                        , Element.height Element.fill
+                        , Element.centerY
+                        , Background.color charcoal
+                        , Border.rounded 2
+                        ]
+                        Element.none
+                    )
+                , height fill
+                , width (px 1)
+                , spacing 0
+                , Background.color charcoal
+                , below (el [ centerX ] (text (String.fromFloat adjustment)))
+                
+                ]
+                { label = Input.labelHidden "font adjustment"
+                , max = maxVal
+                , min = minVal
+                , onChange =
+                    \x ->
+                        UpdateAdjustment
+                            (updateWith x)
+                , step = Just 0.005
+                , thumb =
+                    Input.thumb
+                        [ Element.width (Element.px 16)
+                        , Element.height (Element.px 16)
+                        , Border.rounded 8
+                        , Border.width 1
+                        , Border.color (Element.rgb 0.5 0.5 0.5)
+                        , Background.color (Element.rgb 1 1 1)
+                        ]
+                , value = adjustment
+                }
+        )

--- a/elm-ui15:49:52/experiments/masks/Test.elm
+++ b/elm-ui15:49:52/experiments/masks/Test.elm
@@ -1,0 +1,10 @@
+module Main exposing (..)
+
+{-| -}
+
+import Html
+import MaskedInput
+
+
+main =
+    Html.text "Testing"

--- a/elm-ui15:49:52/experiments/masks/src/MaskedInput.elm
+++ b/elm-ui15:49:52/experiments/masks/src/MaskedInput.elm
@@ -1,0 +1,130 @@
+module MaskedInput exposing (..)
+
+{-| When we've created a Mask, it should be able to:
+
+  - The validator's job is only to say if an entire string is valid.
+      - If a string is valid, then a message is sent out with the updated value.
+      - If a string is not valid, then the last(i.e. the current) value is sent out on a message.
+      - We have to send out a message on every input or else we'll get out of sync.(?)
+
+  - The formatter's job is to take an input string and to format it into a view-string
+
+  - The capturing parser's job is to transform the input string into the desired value.
+      - If the parser fails, we keep returning `Partial`
+      - As soon as it succeeds, we can return `Full`, which can have a value extracted.
+
+First pass at full description.
+
+Mask is defined in a view.
+
+  - An initial string is potentially given.
+  - String is formatted and displayed
+  - onInput handler is registered which parses the value, and creates either a Partial or a Full
+  - The onInput handler will return the formatted string.
+    ->? we could diff it against a previous formatted string to see what changed. Maybe too complicated
+    ->? Capture keyboard events directly and make modifications there. What about pasting?
+    ->! Have the parser operate directly on the formatted string.
+
+-}
+
+import Parser exposing (Parser)
+
+
+type Masked input
+    = Mask
+        { capture : Parser input -- String -> input
+        , format : List Formatter -- tel: "86" -> "(86 )    -    "
+        , validate : List Validator -- Is a character allowed to be typed
+        }
+
+
+type Validator
+    = Validator Int (Char -> Bool)
+
+
+type Formatter
+    = Exactly String
+    | FromInput Int (Maybe Hint) -- hint is shown if no string can be retrieved
+
+
+type alias Hint =
+    String
+
+
+type Captured thing
+    = Partial String
+    | Full thing String
+
+
+capture : input -> Masked input
+capture value =
+    Mask
+        { capture = Parser.succeed value
+        , format = []
+        , validate = []
+        }
+
+
+{-| Shows a static string.
+-}
+show str (Mask mask) =
+    Mask
+        { mask
+            | format = mask.format ++ [ Exactly str ]
+            , capture = Parser.token str
+        }
+
+
+type alias Match =
+    { length : Int
+    , valid : Char -> Bool
+    , hint : Maybe String
+    }
+
+
+{-| -}
+match matcher (Mask mask) =
+    Mask
+        { mask
+            | format = mask.format ++ [ FromInput matcher.length matcher.hint ]
+            , validate = mask.validate ++ [ Validator matcher.length matcher.valid ]
+            , capture = Parser.exactly matcher.length matcher.valid
+        }
+
+
+
+-- map : (a -> b) -> Masked a -> Masked b
+-- map =
+--     Debug.crash "TODO"
+-- map2 :
+--     (a -> b -> value)
+--     -> Masked a
+--     -> Masked b
+--     -> Masked value
+-- map2 =
+--     Debug.crash "TODO"
+
+
+view : String -> Masked input -> Element msg
+view =
+    Debug.crash
+
+
+captureValue : String -> Masked input -> Captured input
+captureValue input (Mask mask) =
+    case Parser.run mask.capture input of
+        Ok val ->
+            Full val input
+
+        Err _ ->
+            Partial input
+
+
+valid : Captured input -> Maybe input
+valid cap =
+    case cap of
+        Partial _ ->
+            Nothing
+
+        Full result _ ->
+            Just result

--- a/elm-ui15:49:52/experiments/workspace/Scrollbars.elm
+++ b/elm-ui15:49:52/experiments/workspace/Scrollbars.elm
@@ -1,0 +1,204 @@
+module Main exposing (main)
+
+{-| -}
+
+import Element exposing (..)
+import Element.Background as Background
+import Element.Font as Font
+
+
+box =
+    el [ height (px 30), width (px 200), Background.color (rgb 0 0.8 0.9) ] none
+
+
+main =
+    Element.layout
+        [ Background.color (rgba 1 1 1 1)
+        , Font.color (rgba 1 1 1 1)
+        , Font.size 64
+
+        -- , Font.italic
+        , Font.family
+            [ Font.external
+                { url = "https://fonts.googleapis.com/css?family=EB+Garamond"
+                , name = "EB Garamond"
+                }
+
+            --   Font.with
+            --     { url = Just "https://fonts.googleapis.com/css?family=EB+Garamond"
+            --     , name = "EB Garamond"
+            --     , adjustment =
+            --         { capital = 1.09
+            --         , lowercase = 0.81
+            --         , baseline = 0.385
+            --         , descender = 0.095
+            --         }
+            --     , variants =
+            --         [ Font.swash 1
+            --         , Font.smallCaps
+            --         -- , Font.diagonalFractions
+            --         -- , Font.ordinal
+            --         -- , Font.ligatures
+            --         ]
+            --     }
+            --   Font.with
+            --     { url = Just "https://fonts.googleapis.com/css?family=Raleway"
+            --     , name = "Raleway"
+            --     , adjustment =
+            --         { capital = 1.09
+            --         , lowercase = 0.81
+            --         , baseline = 0.385
+            --         , descender = 0.095
+            --         }
+            --     , variants =
+            --         [ Font.swash 2
+            --         , Font.ordinal
+            --         , Font.ligatures
+            --         -- , Font.small
+            --         ]
+            --     }
+            , Font.sansSerif
+            ]
+        ]
+    <|
+        column
+            [ spacing 20
+            , Background.color (rgb 1 1 1)
+            , inFront
+                (el
+                    [ Background.color (rgb 1 0 0)
+                    , width (px 20)
+                    , height (px 20)
+                    ]
+                    none
+                )
+            , behindContent
+                (el
+                    [ Background.color (rgb 0.5 0.7 0)
+                    , Font.color (rgb 1 1 1)
+                    , moveDown 30
+                    ]
+                    (text "hi there")
+                )
+            ]
+            [ el
+                [ Background.color (rgba 0 0.9 0.8 1)
+                , Font.color (rgb 0 0 0)
+                , behindContent
+                    (el
+                        [ Background.color (rgb 0.9 0.9 0)
+                        , Font.color (rgb 1 1 1)
+                        ]
+                        (text "hi there")
+                    )
+                , inFront
+                    (el [ Background.color (rgb 0.9 0.9 0.5) ] (text "yo"))
+
+                -- , Font.sizeByCapital
+                -- , Font.variant Font.smallCaps
+                -- , Font.variant Font.ligatures
+                -- , Font.variant Font.diagonalFractions
+                ]
+                (text "Quality 1st Hello stylish friend! ofl 123456  1/3")
+            , el
+                [ Background.color (rgba 0 0.9 0.8 1)
+                , Font.color (rgb 0 0 0)
+                , behindContent
+                    (el [ Background.color (rgb 0.9 0.9 0), Font.color (rgb 1 1 1) ] (text "hi there"))
+                , inFront
+                    (el [ Background.color (rgb 0.9 0.9 0.5) ] (text "yo"))
+
+                -- , Font.sizeByCapital
+                -- , Font.variant Font.smallCaps
+                -- , Font.variant Font.ligatures
+                -- , Font.variant Font.diagonalFractions
+                ]
+                (text "Quality 1st Hello stylish friend! ofl 123456  1/3")
+            , el
+                [ Background.color (rgb 0.1 0.1 0.1)
+                , width (px 200)
+                , height (px 200)
+
+                -- , below
+                --     (el
+                --         [ Background.color (rgb 1 0 0)
+                --         , width (px 20)
+                --         , height (px 20)
+                --         , moveDown 30
+                --         ]
+                --         none
+                --     )
+                , below
+                    (el
+                        [ Background.color (rgb 0.1 0.1 0.6)
+                        , width (px 150)
+                        , height (px 150)
+
+                        -- , alignBottom
+                        ]
+                        none
+                    )
+                ]
+                none
+            , el
+                [ Background.color (rgb 0.1 0.1 0.1)
+                , width (px 200)
+                , height (px 200)
+                , onRight
+                    (el
+                        [ Background.color (rgb 1 0 0)
+                        , width (px 20)
+                        , height fill
+
+                        -- , moveUp 30
+                        ]
+                        none
+                    )
+
+                -- , inFront
+                --     (el
+                --         [ Background.color (rgb 0.1 0.1 0.6)
+                --         , width (px 150)
+                --         , height (px 150)
+                --         ]
+                --         none
+                --     )
+                -- , above
+                --     (el
+                --         [ Background.color (rgb 1 0 0)
+                --         , width (px 20)
+                --         , height (px 20)
+                --         , moveUp 30
+                --         ]
+                --         none
+                --     )
+                ]
+                none
+            ]
+
+
+
+-- row
+--     [ --width (px 420)
+--       padding 0
+--     , spacing 20
+--     , Background.color (rgb 0.2 0.2 0.3)
+--     ]
+--     [ box
+--     , box
+--     , box
+--     -- , box
+--     -- , box
+--     ]
+-- wrappedRow
+--     [ width (px 420)
+--     , padding 10
+--     , spacing 20
+--     , Background.color (rgb 0.2 0.2 0.3)
+--     ]
+--     [ box
+--     , box
+--     , box
+--     , box
+--     , box
+--     ]

--- a/elm-ui15:49:52/experiments/workspace/Table.elm
+++ b/elm-ui15:49:52/experiments/workspace/Table.elm
@@ -1,0 +1,65 @@
+module Main exposing (..)
+
+{-| -}
+
+import Element exposing (..)
+import Element.Background as Background
+import Element.Font as Font
+import Element.Input
+import Element.Lazy
+
+
+type alias Person =
+    { firstName : String
+    , lastName : String
+    }
+
+
+persons : List Person
+persons =
+    [ { firstName = "David"
+      , lastName = "Bowie"
+      }
+    , { firstName = "Florence"
+      , lastName = "Welch"
+      }
+    ]
+
+
+main =
+    Element.layout
+        [ Background.color (rgba 0 0 0 1)
+        , Font.color (rgba 1 1 1 1)
+        , Font.italic
+        , Font.size 32
+        , Font.family
+            [ Font.external
+                { url = "https://fonts.googleapis.com/css?family=EB+Garamond"
+                , name = "EB Garamond"
+                }
+            , Font.sansSerif
+            ]
+        ]
+    <|
+        Element.table
+            [ Element.centerX
+            , Element.centerY
+            , Element.spacing 5
+            , Element.padding 10
+            ]
+            { data = persons
+            , columns =
+                [ { header = Element.text "First Name"
+                  , width = px 200
+                  , view =
+                        \person ->
+                            Element.text person.firstName
+                  }
+                , { header = Element.text "Last Name"
+                  , width = fill
+                  , view =
+                        \person ->
+                            Element.text person.lastName
+                  }
+                ]
+            }

--- a/elm-ui15:49:52/notes/BENCHMARKS.md
+++ b/elm-ui15:49:52/notes/BENCHMARKS.md
@@ -1,0 +1,20 @@
+# Render Benchmark
+
+```bash
+# In root directory
+yarn install
+yarn bench
+```
+
+We're interested in overall rendering performance.  Right now that means measuring:
+
+1. Speed for first paint.
+2. Rerender speed.
+3. FPS for extended animations.
+
+## Some notes about results.
+
+- For the extended animation graph, you see it tops out at a certain point.  That's when the rendering pipeline is maxed out and it's now going below 60fps.
+  
+- The html and inline style cases are **not really** directly comparable to the `elm-ui` stuff because they're not buying you the same thing (which is really write-able, maintainable layouts.)  However they're nice to see because they're the current limit of elm's rendering.
+

--- a/elm-ui15:49:52/notes/CHANGES-FROM-STYLE-ELEMENTS.md
+++ b/elm-ui15:49:52/notes/CHANGES-FROM-STYLE-ELEMENTS.md
@@ -1,0 +1,199 @@
+# Compared to Style Elements
+
+This was a MAJOR rewrite of Style Elements.
+
+* **Major Performance improvement** - Style Elements v5 is much faster than v4 due to a better rendering strategy and generating very minimal html. The rewritten architecture also allows me to explore a few other optimizations, so things may get even faster than they are now.
+
+* **Lazy is here!** - It works with no weird caveats.
+
+## No Stylesheet
+
+You now define styles on the element itself.
+
+```
+el [ Background.color blue, Font.color white ] (text "I'm so stylish!")
+```
+
+These styles are gathered and rendered into a `stylesheet`.  This has a few advantages:
+
+1. Much faster than rendering as actual inline styles
+2. More expressive power by allowing style-elements compile to pseudoclasses, css animations and the like.
+3. Defining styles like this is a really nice workflow.
+
+## Reorganization
+
+* No `Style` modules anymore, it's all under `Element`.
+* `Style.Color` and `Style.Shadow` have been merged into `Element.Font`, `Element.Border`, and `Element.background`.  So things like `Font.color` and `Border.glow` now exist.
+* No more `Element.Attributes`, everything has been either moved to `Element` or to a more appropriate module.
+
+
+## Wait isn't Style Elements about separation of layout and style?!
+
+It was!  So why is there only `Element` and no `StyleSheet` now?
+
+The key insight is that it's not so much the separation of layout and style that is important as it is that _properties affecting layout should all be in the view function_.  The main thing is _not_ having layout specified through several layers of indirection, but having everything explict and in one place.
+
+The new version moves to a more refined version of this idea: **Everything should be explicit and in your view!**
+
+
+## Style Organization
+
+Your next question might be "if we don't have a stylesheet, how to we capture our style logic in a nice way?"
+
+The main thing I've found is that stylesheets in general seem to be pretty hard to maintain.  Even well-typed stylesheets that only allow single classes!  You have to manage names for everything, and in the case of large style refactors it's not obvious that style classes would be organized the same way.
+
+So, I'm not sure that stylesheets or something like stylesheets are the way to go.
+
+My current thinking is that you have 2 really powerful methods of capturing your styling logic.
+
+1. **Just put it in a view function.** If you have a few button variations you want, just create a function for each variation.  You probably don't need a huge number of variations.  You don't need to think of it like recreating bootstrap in style-elements.
+
+2. **Capture your colors, font sizes, etc.**  Create a `Style` module that captures the **values** you use for your styling. Keep your colors there, as well as values for spacing, font names, and font sizes all in one place.  You should consider using a scaling function for things like spacing and fontsizes. 
+
+
+## Element.Region
+
+The `Element.Region` module is now how you can do accessibility markup.
+
+You can do this by adding an area notation to an element's attributes.
+
+```elm
+import Element.Region as Region
+
+row [ Region.navigation ] 
+    [ --..my navigation links
+    ]
+
+```
+Or you can make something an `<h1>`
+
+```
+el [ Region.heading 1 ] (text "Super important stuff")
+
+```
+
+This means your accessibility markup is separate from your layout markup, which turns out to be really nice.
+
+
+
+## Alignment
+
+Alignment got a _bunch_ of attention to make it more powerful and intuitive.
+
+* _Alignment_ now applies to the element it's attached to, so Alignment on `row` and `column` does not apply to the children but to the `row` or `column` itself. 
+
+* _It works everywhere!_  Previously, if you set a child as `alignLeft` in a row, nothing would happen.  The main weirdness that had to be resolved is what happens to the other elements when an el in the middle of a row is aligned.  The answer I came up with is that it will push other elements to the side.
+
+```
+         alignLeft(pushes element on the left of it, to the left)
+         |              center(is the default now)
+         |              |                    alignRight
+         v              v                    v
+  |-el-|-el-|---------|-el-|---------------|-el-|
+```
+
+Also of note, is that if something is `center`, then it will truly be in the center.
+
+* _Centered by Default_ - `el`s are centered by default.
+
+
+## Things that have been removed/deprecated
+
+
+**Percent** - `percent` is no longer there for width/height values. Just use `fill`, because you were probably just using `percent 100`, right?  If you really need something like percent, you can manage it pretty easy with `fillPortion`. The main reason this goes away is that `percent` allows you to accidently overflow your element when trying to sum up multiple elements.
+
+**Grids** - `grid`, and `namedGrid` are gone.  The reason for this is that for 95% of cases, just composing something with `row` and `column` results in _much_ nicer code.  I'm open to see arguments for `grid`, but I need to see specific realworld usecases that can't be done using `row` and `column`.
+
+**WrappedRows/Columns** - `wrappedRow` and `wrappedColumn` are gone.  From what I can see these cases don't show up very often.  Removing them allows me to be cleaner with the internal style-elements code as well.
+
+**When/WhenJust** - `when` and `whenJust` are removed, though you can easily make a convenience function for yourself!  I wanted the library to place an emphasis on common elm constructs instead of library-specific ones.  As far as shortcuts, they don't actually save you much anyway.
+
+**Full, Spacer** - `full` and `spacer` have been removed in order to follow the libraries priority of explicitness.  `full` would override the parents padding, while `spacer` would override the parent's `spacing`.  Both can be achieved with the more common primitives of `row`, `column` and `spacing`, and potentially some nesting of layouts.
+
+
+
+# New Version of the Alpha
+
+- `Font.weight` has been removed in favor of `Font.extraBold`, `Font.regular`, `Font.light`, etc.  All weights from 100 - 900 are represented.
+- `Background.image` and `Background.fittedImage` will place a centered background image, instead of anchoring at the top left.
+- `fill |> minimum 20 |> maximum 200` is now present for `minWidth`, `maxWidth`, `minHeight` and `maxHeight` behavior.  It works like fill, but with an optional top and lower bound.
+- `transparent` - Set an element as transparent.  It will take up space, but otherwise be transparent and unclickable.
+- `alpha` can now be set for an element.
+- `attribute` has been renamed `htmlAttribute` to better convey what it's used for.
+- `Element.Area` has been renamed `Element.Region` to avoid confusion with `WAI ARIA` stuff.
+- `center` has been renamed `centerX`
+
+
+
+# New Default Behavior
+
+The default logic has been made more consistent and hopefully more intuitive.  
+
+All elements start with `width/height shrink`, which means that they are the size of their contents.
+
+
+# PseudoClass Support
+
+`Element.mouseOver`, `Element.focused`, and `Element.mouseDown` are available to style `:hover`, `:focus` and `:active`.  
+
+Only a small subset of properties are allowed here or else the compiler will give you an error.
+
+This also introduced some new type aliases for attributes.
+
+`Attribute msg` - What you're used to.  This **cannot** be used in a mouseOver/focused/etc.
+
+`Attr decorative msg` - A new attribute alias for attributes that can be used as a normal attribute or in `mouseOver`, `focused`, etc.  I like to think of this as a *Decorative Attribute*.
+
+
+# Input
+
+`Input.select` has been removed.  Ultimately this came down to it being recommended against for most UX purposes. 
+
+If you're looking for a replacement, consider any of these options which will likely create a better experience:
+
+- Input.checkbox
+- Input.radio/Input.radioRow with custom styling
+- Input.text with some sort of suggestion/autocomplete attached to it.
+
+If you still need to have a select menu, you can either:
+
+- *Embed one* using `html` 
+- [Craft one by having a hidden `radio` that is shown on focus.](https://gist.github.com/mdgriffith/b99b7ee04eaabaac042572e328a85345)  You'll have to store some state that indicates if the menu is open or not, but you'd have to do that anyway if this library was directly supporting `select`.
+
+*Input.Notices* have been removed, which includes warnings and errors.  Accessibility is important to this library and this change is actually meant to make it easier to have good form validation feedback.
+
+You can just use `above`/`below` when you need to show a validation message and it will be announced politely to users using screen readers.
+
+Notices were originally annotated as errors or warnings so that `aria-invalid` could be attached.  However, it seems to me that having the changes be announced politely is better than having the screen reader just say "Yo, something's invalid".  You now have more control over the feedback!  Craft your messages well :)
+
+
+Type aliases for the records used for inputs were also removed because it gives a nicer error message which references specific fields instead of the top level type alias.
+
+
+
+# New Testing Capabilities
+
+A test suite of ~1.6k layout tests was written(whew!).  All of these tests pass on Chrome, Firefox, Safari, Edge, and IE11.
+
+# Overview of other changes
+
+- `Font.lineHeight` has been removed.  Instead, `spacing` now works on paragraphs.
+- `Element.empty` has been renamed `Element.none` to be more consistent with other elm libraries.
+- `Device` no longer includes `window.width` and `window.height`.  Previously every view function that depends on `device` was forced to rerender when the window was resized, which meant you couldn't take advantage of lazy.  If you do need the window coordinates you can save them separately.
+- *Fewer nodes rendered* - So, things should be faster!
+- `fillBetween` has been replaced by `Element.minimum` and `Element.maximum`.
+
+So now you can do things like
+
+```elm
+view =
+    el 
+        [ width 
+            (fill
+                |> minimum 20
+                |> maximum 200
+            )
+        ]
+        (text "woohoo, I have a min and max")
+
+```

--- a/elm-ui15:49:52/notes/discussion/ColorWithoutAlpha.md
+++ b/elm-ui15:49:52/notes/discussion/ColorWithoutAlpha.md
@@ -1,0 +1,67 @@
+# A Design for Color without Alpha
+
+Color is hard!
+
+I've spent a decade and a half in web development and only now feel like I have some sort of handle on it.
+
+What I've learned basically comes down to the fact that the two color spaces we're used to dealing with (`rgb` and `hsl`), are not actually that great for thinking about color.  Which is unfortunate.
+
+So, what can we use instead?
+
+Research on color perception in the 1920's led to the development of the [CIEXYZ colorspace](https://en.wikipedia.org/wiki/CIE_1931_color_space), which describes color in a way that is much closer to how humans perceive color.  Essentially they were able to model constants in their equations that literally represent some of the built-in values we have as humans to perceive color. 
+
+How crazy is that?
+
+(Skipping over the fact that there is variation in how people perceive color.)
+
+There are a number of color spaces that are based on this initial research, including CIELAB(generally recommended for print), and CIELUV(generally recommended for light).  They are essentailly different ways to talk about the same color space.  Sorta like polar coordinates(r,θ) and cartesian coordiantes (x,y) can both represent a point.
+
+The `L` in the above acronyms represents `Luminance`.
+
+This is one of the really cool parts.  Two colors that have the same `Luminance`, will be equally "bright" to the human eye.
+
+You might be thinking "well, what about the `lightness` channel in `HSL`, huh?".  Turns out it's not really based on anything! 
+
+Here are two hsl colors with the same lightness:
+![](http://lea.verou.me/wp-content/uploads/2020/04/image-4.png)
+
+Do they look like the same "brightness"?
+
+Unfortunately the L in HSL stands for Lies and we've been misled all along.
+
+[This whole article on color spaces is worth a read if you got the time](http://lea.verou.me/2020/04/lch-colors-in-css-what-why-and-how/)
+
+
+Ok, so, luminance is really cool. 
+
+With a real `Luminance` factor you can
+    1. Generate palettes of colors that work together in a consistent manner.
+    2. Automatically know the difference in luminance between two colors.  Guess what that is.  It's a contrast calculation!  Like for accessibility!  How nice would that be if it was X - Y as opposed to some crazy math?
+    3. Get an intuition for how colors will interact with each other.
+    4. Generate gradients that aren't unexpectedly broken. (I have some examples of this, I'll dig them up later)
+    5. Animate colors consistently.  Animating in rgb or hsl will cause color animation to look awful in different ways.
+
+It really is a better world.
+
+Ok, so how do we get there and what does this mean for elm-ui?
+
+
+# Elm UI stuff
+
+The above knowledge is hard won.  Many people are not aware that there are better colorspaces than rgb and hsl.
+
+Color is hard.  In many cases, it will remain hard until people get a nice introduction to something based on CIEXYZ.
+
+In elm, [we have a package for HSLuv](
+https://package.elm-lang.org/packages/kuon/elm-hsluv/latest/), which you can use right now. It's great.
+
+However!  We have one confouding factor, which is that we're used to bundling an `alpha` value with our colors.
+
+The same math that makes rgb and hsl less than great is used to blend colors via alpha.
+
+By bundling alpha with color, we're encouranging people to blend colors in an ad-hoc way when we could be providing them avenues to easily do it the right way. We have a whole programming language, we're not confined to only CSS anymore.
+
+However!  Frontend development also involves talking to designers.  Designers usually provide rgb, hsl, or a hex version of rgb.
+
+I now sorta view these as *interop formats*.
+

--- a/elm-ui15:49:52/src/Ui/Anim.elm
+++ b/elm-ui15:49:52/src/Ui/Anim.elm
@@ -1,0 +1,788 @@
+module Ui.Anim exposing
+    ( layout
+    , init, Msg, update, State
+    , transition, intro, hovered, focused, active
+    , Duration, ms
+    , Animated, opacity
+    , x, y, z
+    , rotation, rotationAround
+    , scale, scaleX, scaleY, scaleZ
+    , backgroundColor, fontColor, borderColor
+    , Transition, withTransition, withStepTransition
+    , linear, spring, bezier
+    , spinning, pulsing, bouncing, pinging
+    , keyframes, hoveredWith, focusedWith, activeWith
+    , Step, set, wait, step
+    , loop, loopFor
+    , onHover, onFocus, onActive
+    , Timeline, onTimeline, onTimelineWith
+    , mapAttribute
+    )
+
+{-|
+
+
+# Getting set up
+
+@docs layout
+
+@docs init, Msg, update, State
+
+
+# Animations
+
+@docs transition, intro, hovered, focused, active
+
+@docs Duration, ms
+
+
+# Properties
+
+@docs Animated, opacity
+
+@docs x, y, z
+
+@docs rotation, rotationAround
+
+@docs scale, scaleX, scaleY, scaleZ
+
+@docs backgroundColor, fontColor, borderColor
+
+
+# Transitions
+
+@docs Transition, withTransition, withStepTransition
+
+@docs linear, spring, bezier
+
+-- @docs padding, paddingEach, backgroundColor, border, font, height, width
+
+
+# Premade animations
+
+Here are some premade animations.
+
+There's nothing special about them, they're just convenient!
+
+Check out how they're defined if you want to make your own.
+
+@docs spinning, pulsing, bouncing, pinging
+
+
+# Keyframes
+
+@docs keyframes, hoveredWith, focusedWith, activeWith
+
+@docs Step, set, wait, step
+
+@docs loop, loopFor
+
+
+# Parent triggers
+
+@docs onHover, onFocus, onActive
+
+
+# Timelines
+
+@docs Timeline, onTimeline, onTimelineWith
+
+
+# Mapping
+
+@docs mapAttribute
+
+-}
+
+import Animator
+import Animator.Timeline
+import Animator.Transition
+import Color
+import Html
+import Internal.BitEncodings as Bits
+import Internal.BitField as BitField
+import Internal.Flag as Flag
+import Internal.Model2 as Two
+import Internal.Style2 as Style
+import Internal.Teleport as Teleport
+import InternalAnim.Css as Css
+import Json.Decode as Decode
+import Json.Encode as Encode
+import Set
+import Time
+import Ui exposing (Attribute, Color, Element)
+import Ui.Events
+import Ui.Responsive
+
+
+{-| -}
+type alias Animated =
+    Animator.Attribute
+
+
+{-| -}
+type alias Transition =
+    Animator.Transition.Transition
+
+
+{-| -}
+linear : Transition
+linear =
+    Animator.Transition.linear
+
+
+{-| -}
+spring :
+    { wobble : Float
+    , quickness : Float
+    }
+    -> Transition
+spring =
+    Animator.Transition.spring
+
+
+{-| -}
+bezier : Float -> Float -> Float -> Float -> Transition
+bezier one two three four =
+    Animator.Transition.bezier one two three four
+
+
+{-| -}
+withTransition : Transition -> Animated -> Animated
+withTransition =
+    Animator.withTransition
+
+
+{-| -}
+withStepTransition : Transition -> Step -> Step
+withStepTransition =
+    Animator.withStepTransition
+
+
+{-| -}
+type alias Timeline state =
+    Animator.Timeline.Timeline state
+
+
+{-| -}
+onTimeline : Timeline state -> (state -> List Animated) -> Attribute msg
+onTimeline timeline fn =
+    Animator.css timeline (\state -> ( fn state, [] ))
+        |> toAttr OnRender
+
+
+{-| -}
+type alias Step =
+    Animator.Step
+
+
+{-| -}
+set : List Animated -> Step
+set =
+    Animator.set
+
+
+{-| -}
+wait : Duration -> Step
+wait =
+    Animator.wait
+
+
+{-| -}
+step : Duration -> List Animated -> Step
+step =
+    Animator.step
+
+
+{-| -}
+loop : List Step -> Step
+loop =
+    Animator.loop
+
+
+{-| -}
+loopFor : Int -> List Step -> Step
+loopFor =
+    Animator.loopFor
+
+
+
+{- Triggers -}
+
+
+onRenderTrigger : String
+onRenderTrigger =
+    "on-rendered"
+
+
+onHoverTrigger : String
+onHoverTrigger =
+    "on-hovered"
+
+
+onFocusTrigger : String
+onFocusTrigger =
+    "on-focused"
+
+
+onFocusWithinTrigger : String
+onFocusWithinTrigger =
+    "on-focused-within"
+
+
+onActiveTrigger : String
+onActiveTrigger =
+    "on-activated"
+
+
+
+{- Animation stuff -}
+
+
+type Trigger
+    = Hover
+    | Focus
+    | Active
+    | OnRender
+
+
+triggerClass : Trigger -> String
+triggerClass trigger =
+    case trigger of
+        Hover ->
+            onHoverTrigger
+
+        Focus ->
+            onFocusTrigger
+
+        Active ->
+            onActiveTrigger
+
+        OnRender ->
+            onRenderTrigger
+
+
+triggerPsuedo : Trigger -> String
+triggerPsuedo trigger =
+    case trigger of
+        Hover ->
+            ":hover"
+
+        Focus ->
+            ":focus"
+
+        Active ->
+            ":active"
+
+        OnRender ->
+            ""
+
+
+addTriggerToCssClass : Trigger -> Animator.Css -> Animator.Css
+addTriggerToCssClass trigger css =
+    { css
+        | hash =
+            triggerClass trigger ++ css.hash
+    }
+
+
+toAttr : Trigger -> Animator.Css -> Attribute msg
+toAttr trigger incomingCss =
+    let
+        css =
+            incomingCss
+                |> addTriggerToCssClass trigger
+
+        props =
+            if css.transition == "" then
+                []
+
+            else
+                [ ( "transition", css.transition ) ]
+    in
+    Two.teleport
+        { trigger = triggerClass trigger
+        , class = css.hash
+        , style =
+            case trigger of
+                OnRender ->
+                    incomingCss.props ++ props
+
+                _ ->
+                    props
+        , data =
+            css
+                |> Teleport.encodeCss (triggerPsuedo trigger) incomingCss.hash
+        }
+
+
+transitionWithTrigger : Trigger -> Duration -> List Animated -> Attribute msg
+transitionWithTrigger trigger dur attrs =
+    Animator.css
+        (Animator.Timeline.init []
+            |> Animator.Timeline.to dur attrs
+            |> Animator.Timeline.update (Time.millisToPosix 1)
+        )
+        (\animated ->
+            ( animated, [] )
+        )
+        |> toAttr trigger
+
+
+addPsuedoClass : String -> Animator.Css -> Animator.Css
+addPsuedoClass psuedo css =
+    { css
+        | hash = css.hash ++ psuedo
+    }
+
+
+{-| -}
+transition : Duration -> List Animated -> Attribute msg
+transition dur attrs =
+    let
+        css =
+            Animator.css
+                (Animator.Timeline.init []
+                    |> Animator.Timeline.to dur attrs
+                    |> Animator.Timeline.update (Time.millisToPosix 1)
+                )
+                (\animated ->
+                    ( animated, [] )
+                )
+    in
+    Two.styleList css.props
+
+
+{-| -}
+intro :
+    Duration
+    ->
+        { start : List Animated
+        , to : List Animated
+        }
+    -> Attribute msg
+intro dur attrs =
+    -- we do this because we have to render css keyframes
+    Animator.keyframes
+        [ Animator.set attrs.start
+        , Animator.step dur attrs.to
+        ]
+        |> Animator.toCss
+        |> toAttr OnRender
+
+
+{-| -}
+hovered : Duration -> List Animated -> Attribute msg
+hovered dur attrs =
+    transitionWithTrigger Hover dur attrs
+
+
+{-| -}
+focused : Duration -> List Animated -> Attribute msg
+focused dur attrs =
+    transitionWithTrigger Focus dur attrs
+
+
+{-| -}
+active : Duration -> List Animated -> Attribute msg
+active dur attrs =
+    transitionWithTrigger Active dur attrs
+
+
+
+{- Default transitions -}
+
+
+{-| -}
+linearCurve : BitField.Bits
+linearCurve =
+    encodeBezier 0 0 1 1
+
+
+{-| cubic-bezier(0.4, 0.0, 0.2, 1);
+Standard curve as given here: <https://material.io/design/motion/speed.html#easing>
+-}
+standardCurve : BitField.Bits
+standardCurve =
+    encodeBezier 0.4 0 0.2 1
+
+
+encodeBezier : Float -> Float -> Float -> Float -> BitField.Bits
+encodeBezier one two three four =
+    BitField.init
+        |> BitField.setPercentage Bits.bezOne one
+        |> BitField.setPercentage Bits.bezTwo two
+        |> BitField.setPercentage Bits.bezThree three
+        |> BitField.setPercentage Bits.bezFour four
+
+
+{-| -}
+fontColor : Color -> Animated
+fontColor clr =
+    Animator.color "color" clr
+
+
+{-| -}
+backgroundColor : Color -> Animated
+backgroundColor clr =
+    Animator.color "background-color" clr
+
+
+{-| -}
+borderColor : Color -> Animated
+borderColor clr =
+    Animator.color "border-color" clr
+
+
+{-| -}
+opacity : Float -> Animated
+opacity =
+    Animator.opacity
+
+
+{-| -}
+scale : Float -> Animated
+scale =
+    Animator.scale
+
+
+{-| -}
+scaleX : Float -> Animated
+scaleX =
+    Animator.scaleX
+
+
+{-| -}
+scaleY : Float -> Animated
+scaleY =
+    Animator.scaleY
+
+
+{-| -}
+scaleZ : Float -> Animated
+scaleZ =
+    Animator.scaleZ
+
+
+{-| -}
+rotation : Float -> Animated
+rotation =
+    Animator.rotation
+
+
+{-| -}
+rotationAround :
+    { x : Float
+    , y : Float
+    , z : Float
+    }
+    -> Float
+    -> Animated
+rotationAround =
+    Animator.rotationAround
+
+
+{-| -}
+x : Float -> Animated
+x =
+    Animator.x
+
+
+{-| -}
+y : Float -> Animated
+y =
+    Animator.y
+
+
+{-| -}
+z : Float -> Animated
+z =
+    Animator.z
+
+
+{-| -}
+padding : Int -> Animated
+padding p =
+    Animator.int "padding" (toFloat p)
+
+
+
+{- DURATIONS! -}
+
+
+{-| -}
+type alias Duration =
+    Animator.Duration
+
+
+{-| -}
+ms : Float -> Duration
+ms =
+    Animator.ms
+
+
+{-| -}
+spinning : Duration -> Attribute msg
+spinning dur =
+    Animator.spinning dur
+        |> Animator.toCss
+        |> toAttr OnRender
+
+
+{-| -}
+pulsing : Duration -> Attribute msg
+pulsing dur =
+    Animator.pulsing dur
+        |> Animator.toCss
+        |> toAttr OnRender
+
+
+{-| -}
+bouncing : Duration -> Float -> Attribute msg
+bouncing dur distance =
+    Animator.bouncing dur distance
+        |> Animator.toCss
+        |> toAttr OnRender
+
+
+{-| -}
+pinging : Duration -> Attribute msg
+pinging dur =
+    Animator.pinging dur
+        |> Animator.toCss
+        |> toAttr OnRender
+
+
+
+{- Advanced -}
+
+
+{-| -}
+onTimelineWith :
+    Timeline state
+    ->
+        (state
+         -> ( List Animated, List Step )
+        )
+    -> Attribute msg
+onTimelineWith timeline fn =
+    Animator.css timeline fn
+        |> toAttr OnRender
+
+
+{-| -}
+onHover :
+    String
+    ->
+        { onHover : Attribute msg
+        , keyframes : List Step -> Attribute msg
+        }
+onHover identifier =
+    { onHover =
+        Two.teleportTrigger
+            { trigger = onHoverTrigger
+            , identifierClass = identifier
+            }
+    , keyframes =
+        \steps ->
+            Animator.keyframes steps
+                |> Animator.toCss
+                |> toReactionAttr identifier Hover
+    }
+
+
+{-| -}
+onFocus :
+    String
+    ->
+        { onFocus : Attribute msg
+        , keyframes : List Step -> Attribute msg
+        }
+onFocus identifier =
+    { onFocus =
+        Two.teleportTrigger
+            { trigger = onFocusTrigger
+            , identifierClass = identifier
+            }
+    , keyframes =
+        \steps ->
+            Animator.keyframes steps
+                |> Animator.toCss
+                |> toReactionAttr identifier Focus
+    }
+
+
+{-| -}
+onActive :
+    String
+    ->
+        { onActive : Attribute msg
+        , keyframes : List Step -> Attribute msg
+        }
+onActive identifier =
+    { onActive =
+        Two.teleportTrigger
+            { trigger = onActiveTrigger
+            , identifierClass = identifier
+            }
+    , keyframes =
+        \steps ->
+            Animator.keyframes steps
+                |> Animator.toCss
+                |> toReactionAttr identifier Active
+    }
+
+
+toReactionAttr : String -> Trigger -> Animator.Css -> Attribute msg
+toReactionAttr identifier trigger incomingCss =
+    let
+        css =
+            incomingCss
+                |> addTriggerToCssClass trigger
+
+        props =
+            if css.transition == "" then
+                []
+
+            else
+                [ ( "transition", css.transition ) ]
+    in
+    Two.teleportReaction
+        { trigger = triggerClass trigger
+        , identifierClass = identifier
+        , class = css.hash
+        , style =
+            List.filter (\( name, _ ) -> name /= "animation") incomingCss.props
+                ++ props
+        , data =
+            css
+                |> Teleport.encodeChildReaction (triggerPsuedo trigger) identifier incomingCss.hash
+        }
+
+
+{-| -}
+keyframes : List Step -> Attribute msg
+keyframes steps =
+    Animator.keyframes steps
+        |> Animator.toCss
+        |> toAttr OnRender
+
+
+{-| -}
+hoveredWith : List Step -> Attribute msg
+hoveredWith steps =
+    Animator.keyframes steps
+        |> Animator.toCss
+        |> toAttr Hover
+
+
+{-| -}
+focusedWith : List Step -> Attribute msg
+focusedWith steps =
+    Animator.keyframes steps
+        |> Animator.toCss
+        |> toAttr Focus
+
+
+{-| -}
+activeWith : List Step -> Attribute msg
+activeWith steps =
+    Animator.keyframes steps
+        |> Animator.toCss
+        |> toAttr Active
+
+
+
+{- SETUP -}
+
+
+{-| -}
+layout :
+    { options : List Ui.Option
+    , toMsg : Msg -> msg
+    , breakpoints : Maybe (Ui.Responsive.Breakpoints label)
+    }
+    -> State
+    -> List (Attribute msg)
+    -> Element msg
+    -> Html.Html msg
+layout opts state attrs els =
+    Two.renderLayout
+        { options =
+            case opts.breakpoints of
+                Just (Two.Responsive breakpoints) ->
+                    breakpoints.breakpoints :: opts.options
+
+                Nothing ->
+                    opts.options
+        , includeStaticStylesheet = True
+        }
+        state
+        (onAnimationStart opts.toMsg
+            :: onAnimationUnmount opts.toMsg
+            :: attrs
+        )
+        els
+
+
+onAnimationStart : (Msg -> msg) -> Ui.Attribute msg
+onAnimationStart onMsg =
+    Ui.Events.on "animationstart"
+        (Decode.field "animationName" Decode.string
+            |> Decode.andThen
+                (\name ->
+                    case Teleport.stringToTrigger name of
+                        Just trigger ->
+                            Decode.map (onMsg << Two.Teleported trigger) Teleport.decode
+
+                        Nothing ->
+                            Decode.fail "Nonmatching animation"
+                )
+        )
+
+
+onAnimationUnmount : (Msg -> msg) -> Ui.Attribute msg
+onAnimationUnmount onMsg =
+    Ui.Events.on "animationcancel"
+        (Decode.field "animationName" Decode.string
+            |> Decode.andThen
+                (\name ->
+                    if name == "on-dismount" then
+                        Decode.map (onMsg << Two.Teleported Teleport.OnDismount) Teleport.decode
+
+                    else
+                        Decode.fail "Nonmatching animation"
+                )
+        )
+
+
+{-| -}
+init : State
+init =
+    Two.State
+        { added = Set.empty
+        , rules = []
+        , keyframes = []
+        }
+
+
+{-| -}
+type alias State =
+    Two.State
+
+
+{-| -}
+type alias Msg =
+    Two.Msg
+
+
+{-| -}
+mapAttribute : (msg -> msg2) -> Attribute msg -> Attribute msg2
+mapAttribute =
+    Two.mapAttr
+
+
+{-| -}
+update : (Msg -> msg) -> Msg -> State -> ( State, Cmd msg )
+update =
+    Two.update

--- a/elm-ui15:49:52/src/Ui/Events.elm
+++ b/elm-ui15:49:52/src/Ui/Events.elm
@@ -1,0 +1,521 @@
+module Ui.Events exposing
+    ( onClick
+    , onDoubleClick, onMouseDown, onMouseUp, onMouseEnter, onMouseLeave, onMouseMove
+    , onFocus, onLoseFocus
+    , onKey
+    , Key, enter, space, up, down, left, right, backspace, key
+    , on, stopPropagationOn, preventDefaultOn, custom
+    )
+
+{-|
+
+
+# Mouse
+
+@docs onClick
+
+@docs onDoubleClick, onMouseDown, onMouseUp, onMouseEnter, onMouseLeave, onMouseMove
+
+
+# Focus
+
+@docs onFocus, onLoseFocus
+
+
+# Keyboard
+
+@docs onKey
+
+@docs Key, enter, space, up, down, left, right, backspace, key
+
+
+# Custom
+
+@docs on, stopPropagationOn, preventDefaultOn, custom
+
+-}
+
+import Html.Events
+import Internal.Flag as Flag
+import Internal.Model2 as Two
+import Json.Decode as Json exposing (Decoder)
+import Ui exposing (Attribute)
+
+
+
+-- MOUSE EVENTS
+
+
+{-| -}
+onClick : msg -> Attribute msg
+onClick msg =
+    Two.attribute (Html.Events.onClick msg)
+
+
+{-| -}
+onDoubleClick : msg -> Attribute msg
+onDoubleClick msg =
+    Two.attribute (Html.Events.onDoubleClick msg)
+
+
+{-| -}
+onMouseEnter : msg -> Attribute msg
+onMouseEnter msg =
+    Two.attribute (Html.Events.onMouseEnter msg)
+
+
+{-| -}
+onMouseLeave : msg -> Attribute msg
+onMouseLeave msg =
+    Two.attribute (Html.Events.onMouseLeave msg)
+
+
+{-| -}
+onMouseMove : msg -> Attribute msg
+onMouseMove msg =
+    on "mousemove" (Json.succeed msg)
+
+
+{-| -}
+onMouseDown : msg -> Attribute msg
+onMouseDown =
+    Two.attribute << Html.Events.onMouseDown
+
+
+{-| -}
+onMouseUp : msg -> Attribute msg
+onMouseUp =
+    Two.attribute << Html.Events.onMouseUp
+
+
+
+-- onClickWith
+--     { button = primary
+--     , send = localCoords Button
+--     }
+-- type alias Click =
+--     { button : Button
+--     , send : Track
+--     }
+-- type Button = Primary | Secondary
+-- type Track
+--     = ElementCoords
+--     | PageCoords
+--     | ScreenCoords
+-- |
+
+
+{-| -}
+onClickCoords : (Coords -> msg) -> Attribute msg
+onClickCoords msg =
+    on "click" (Json.map msg localCoords)
+
+
+{-| -}
+onClickScreenCoords : (Coords -> msg) -> Attribute msg
+onClickScreenCoords msg =
+    on "click" (Json.map msg screenCoords)
+
+
+{-| -}
+onClickPageCoords : (Coords -> msg) -> Attribute msg
+onClickPageCoords msg =
+    on "click" (Json.map msg pageCoords)
+
+
+{-| -}
+onMouseCoords : (Coords -> msg) -> Attribute msg
+onMouseCoords msg =
+    on "mousemove" (Json.map msg localCoords)
+
+
+{-| -}
+onMouseScreenCoords : (Coords -> msg) -> Attribute msg
+onMouseScreenCoords msg =
+    on "mousemove" (Json.map msg screenCoords)
+
+
+{-| -}
+onMousePageCoords : (Coords -> msg) -> Attribute msg
+onMousePageCoords msg =
+    on "mousemove" (Json.map msg pageCoords)
+
+
+type alias Coords =
+    { x : Int
+    , y : Int
+    }
+
+
+screenCoords : Json.Decoder Coords
+screenCoords =
+    Json.map2 Coords
+        (Json.field "screenX" Json.int)
+        (Json.field "screenY" Json.int)
+
+
+{-| -}
+localCoords : Json.Decoder Coords
+localCoords =
+    Json.map2 Coords
+        (Json.field "offsetX" Json.int)
+        (Json.field "offsetY" Json.int)
+
+
+pageCoords : Json.Decoder Coords
+pageCoords =
+    Json.map2 Coords
+        (Json.field "pageX" Json.int)
+        (Json.field "pageY" Json.int)
+
+
+
+-- FOCUS EVENTS
+
+
+{-| -}
+onLoseFocus : msg -> Attribute msg
+onLoseFocus =
+    Two.attribute << Html.Events.onBlur
+
+
+{-| -}
+onFocus : msg -> Attribute msg
+onFocus =
+    Two.attribute << Html.Events.onFocus
+
+
+
+-- {-| Same as `on` but you can set a few options.
+-- -}
+-- onWithOptions : String -> Html.Events.Options -> Json.Decoder msg -> Attribute msg
+-- onWithOptions event options decode =
+--     Two.Attr <| Html.Events.onWithOptions event options decode
+-- COMMON DECODERS
+
+
+{-| A `Json.Decoder` for grabbing `event.target.value`. We use this to define
+`onInput` as follows:
+
+    import Json.Decode as Json
+
+    onInput : (String -> msg) -> Attribute msg
+    onInput tagger =
+        on "input" (Json.map tagger targetValue)
+
+You probably will never need this, but hopefully it gives some insights into
+how to make custom event handlers.
+
+-}
+targetValue : Json.Decoder String
+targetValue =
+    Json.at [ "target", "value" ] Json.string
+
+
+{-| A `Json.Decoder` for grabbing `event.target.checked`. We use this to define
+`onCheck` as follows:
+
+    import Json.Decode as Json
+
+    onCheck : (Bool -> msg) -> Attribute msg
+    onCheck tagger =
+        on "input" (Json.map tagger targetChecked)
+
+-}
+targetChecked : Json.Decoder Bool
+targetChecked =
+    Json.at [ "target", "checked" ] Json.bool
+
+
+{-| A `Json.Decoder` for grabbing `event.keyCode`. This helps you define
+keyboard listeners like this:
+
+    import Json.Decode as Json
+
+    onKeyUp : (Int -> msg) -> Attribute msg
+    onKeyUp tagger =
+        on "keyup" (Json.map tagger keyCode)
+
+**Note:** It looks like the spec is moving away from `event.keyCode` and
+towards `event.key`. Once this is supported in more browsers, we may add
+helpers here for `onKeyUp`, `onKeyDown`, `onKeyPress`, etc.
+
+-}
+keyCode : Json.Decoder Int
+keyCode =
+    Json.field "keyCode" Json.int
+
+
+
+{- Keyboard -}
+
+
+{-| -}
+onKey : Key -> msg -> Attribute msg
+onKey desiredKey msg =
+    Two.onKey
+        { key = toCodeString desiredKey
+        , msg = msg
+        }
+
+
+
+-- {-| -}
+-- onKeyWith :
+--     ({ key : Key
+--      , ctrl : Bool
+--      , alt : Bool
+--      , shift : Bool
+--      , meta : Bool
+--      }
+--      -> Maybe msg
+--     )
+--     -> Attribute msg
+-- onKeyWith toMsg =
+--     Two.Attribute
+--         { flag = Flag.event
+--         , attr =
+--             Two.OnKey
+--                 (Html.Events.preventDefaultOn "keyup"
+--                     (decodeKeyboardEvent
+--                         |> Json.map2 Tuple.pair decodeIMEComposition
+--                         |> Json.andThen
+--                             (\( isComposing, keyDetails ) ->
+--                                 case toMsg keyDetails of
+--                                     Nothing ->
+--                                         Json.fail "Ignored"
+--                                     Just msg ->
+--                                         if isComposing then
+--                                             Json.fail "IME composing is ignored"
+--                                         else
+--                                             Json.succeed ( msg, True )
+--                             )
+--                     )
+--                 )
+--         }
+
+
+decodeKeyboardEvent :
+    Json.Decoder
+        { key : Key
+        , ctrl : Bool
+        , alt : Bool
+        , shift : Bool
+        , meta : Bool
+        }
+decodeKeyboardEvent =
+    Json.map5
+        (\keyStr ctrl alt shift meta ->
+            { key = toKey keyStr
+            , ctrl = ctrl
+            , alt = alt
+            , shift = shift
+            , meta = meta
+            }
+        )
+        (Json.field "key" Json.string)
+        (Json.field "ctrlKey" Json.bool)
+        (Json.field "altKey" Json.bool)
+        (Json.field "shiftKey" Json.bool)
+        (Json.field "metaKey" Json.bool)
+
+
+{-| This property is true if the user is using IME to craft something like a Korean character.
+
+I _think_ for this usecase that means we want to ignore the character.
+
+But am not totally sure :/ If you run into a case where this is not true, please let me know!
+
+<https://developer.mozilla.org/en-US/docs/Web/API/Document/keyup_event#ignoring_keyup_during_ime_composition>
+
+-}
+decodeIMEComposition : Json.Decoder Bool
+decodeIMEComposition =
+    Json.field "isComposing" Json.bool
+
+
+{-| -}
+type Key
+    = Enter
+    | Space
+    | Up
+    | Down
+    | Left
+    | Right
+    | Backspace
+    | Key String
+
+
+{-| -}
+enter : Key
+enter =
+    Enter
+
+
+{-| -}
+space : Key
+space =
+    Space
+
+
+{-| -}
+up : Key
+up =
+    Up
+
+
+{-| -}
+down : Key
+down =
+    Down
+
+
+{-| -}
+left : Key
+left =
+    Left
+
+
+{-| -}
+right : Key
+right =
+    Right
+
+
+{-| -}
+backspace : Key
+backspace =
+    Backspace
+
+
+{-| -}
+key : String -> Key
+key =
+    Key
+
+
+toKey : String -> Key
+toKey str =
+    case str of
+        "Enter" ->
+            Enter
+
+        "Space" ->
+            Space
+
+        "ArrowUp" ->
+            Up
+
+        "ArrowDown" ->
+            Down
+
+        "ArrowLeft" ->
+            Left
+
+        "ArrowRight" ->
+            Right
+
+        "Backspace" ->
+            Backspace
+
+        _ ->
+            Key str
+
+
+toCodeString : Key -> String
+toCodeString myKey =
+    case myKey of
+        Enter ->
+            "Enter"
+
+        Space ->
+            "Space"
+
+        Up ->
+            "ArrowUp"
+
+        Down ->
+            "ArrowDown"
+
+        Left ->
+            "ArrowLeft"
+
+        Right ->
+            "ArrowRight"
+
+        Backspace ->
+            "Backspace"
+
+        Key str ->
+            str
+
+
+
+{- Custom -}
+
+
+{-| -}
+on : String -> Decoder msg -> Attribute msg
+on name decoder =
+    Two.attribute (Html.Events.on name decoder)
+
+
+{-| -}
+stopPropagationOn : String -> Decoder ( msg, Bool ) -> Attribute msg
+stopPropagationOn name decoder =
+    Two.attribute (Html.Events.stopPropagationOn name decoder)
+
+
+{-| -}
+preventDefaultOn : String -> Decoder ( msg, Bool ) -> Attribute msg
+preventDefaultOn name decoder =
+    Two.attribute (Html.Events.preventDefaultOn name decoder)
+
+
+{-| -}
+custom :
+    String
+    ->
+        Decoder
+            { message : msg
+            , stopPropagation : Bool
+            , preventDefault : Bool
+            }
+    -> Attribute msg
+custom name decoder =
+    Two.attribute (Html.Events.custom name decoder)
+
+
+{-| Decodes a given
+[`Event`](http://developer.mozilla.org/en-US/docs/Web/API/Event) into a `Bool`
+which indicates whether or not the the event's
+[`target`](http://developer.mozilla.org/en-US/docs/Web/API/Event/target) is a
+child of the `HTMLElement`s identified by the given
+[`id`](http://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/id)s.
+
+Implementation adapted from
+<https://dev.to/margaretkrutikova/elm-dom-node-decoder-to-detect-click-outside-3ioh>.
+
+-}
+isOutsideTargetDecoder : List String -> Decoder Bool
+isOutsideTargetDecoder htmlIds =
+    htmlIds
+        |> isOutsideElementsDecoder
+        |> Json.field "target"
+
+
+isOutsideElementsDecoder : List String -> Decoder Bool
+isOutsideElementsDecoder htmlIds =
+    Json.oneOf
+        [ Json.field "id" Json.string
+            |> Json.andThen
+                (\htmlId_ ->
+                    if List.member htmlId_ htmlIds then
+                        Json.succeed False
+
+                    else
+                        Json.fail "check parent node"
+                )
+        , Json.lazy (\_ -> isOutsideElementsDecoder htmlIds |> Json.field "parentNode")
+        , Json.succeed True
+        ]

--- a/elm-ui15:49:52/tests-rendering/cases/Manual/LazyPerformance.elm
+++ b/elm-ui15:49:52/tests-rendering/cases/Manual/LazyPerformance.elm
@@ -1,0 +1,523 @@
+module Tests.Manual.LazyPerformance exposing (..)
+
+{-
+
+   We want to make sure that lazy is able to perform correctly in style-elements.
+
+   For the setup:
+
+   Render an expensive thing in html.
+
+   Rerender with Lazy.
+
+
+
+
+
+
+-}
+
+import Element
+import Element.Lazy
+import Html exposing (Html)
+import Html.Attributes
+import Html.Events
+import Html.Lazy
+import Internal.Model
+
+
+subscriptions : Model -> Sub Msg
+subscriptions model =
+    Sub.none
+
+
+init : ( Model, Cmd Msg )
+init =
+    ( { renderAs = NothingPlease, count = 0 }, Cmd.none )
+
+
+main : Program Never Model Msg
+main =
+    Html.program
+        { init = init
+        , view = view
+        , update = update
+        , subscriptions = subscriptions
+        }
+
+
+type alias Model =
+    { renderAs : Render
+    , count : Int
+    }
+
+
+type Render
+    = HtmlPlease
+    | StylePlease
+    | NothingPlease
+
+
+type Msg
+    = RenderAs Render
+
+
+update : Msg -> Model -> ( Model, Cmd Msg )
+update msg model =
+    case msg of
+        RenderAs mode ->
+            ( { model
+                | renderAs = mode
+                , count =
+                    if mode == model.renderAs then
+                        model.count + 1
+                    else
+                        0
+              }
+            , Cmd.none
+            )
+
+
+view : Model -> Html Msg
+view model =
+    Html.div []
+        [ Html.button [ Html.Events.onClick <| RenderAs HtmlPlease ] [ Html.text "Html, Please" ]
+        , Html.button [ Html.Events.onClick <| RenderAs StylePlease ] [ Html.text "Style, Please" ]
+        , Html.div [] [ Html.text (toString model.count) ]
+        , case model.renderAs of
+            HtmlPlease ->
+                Html.div []
+                    [ staticStyleSheet
+                    , Html.Lazy.lazy viewHtml 10000
+                    ]
+
+            StylePlease ->
+                Element.layout []
+                    (Element.Lazy.lazy viewStyle 10000)
+
+            NothingPlease ->
+                Html.text "Nothing rendered.."
+        ]
+
+
+
+-- on second render, js time goes down to single digit ms, small bit of updating layout, and updating layout tree.
+
+
+viewHtml x =
+    Html.div [ Html.Attributes.class "se column spacing-20-20 content-top height-fill width-fill" ]
+        (List.repeat x (Html.div [ Html.Attributes.class "se el width-content height-content self-center-y self-center-x" ] [ Html.div [ Html.Attributes.class "se text width-fill" ] [ Html.text "hello!" ] ]))
+
+
+viewStyle x =
+    Element.column []
+        (List.repeat x (Element.el [] (Element.text "hello!")))
+
+
+staticStyleSheet =
+    Html.node "style"
+        []
+        [ Html.text """
+html {
+  height: 100%;
+}
+
+body {
+  height: 100%;
+}
+
+input {
+  border: none;
+}
+
+a {
+  text-decoration: none;
+  color: inherit;
+}
+
+.style-elements {
+  width: 100%;
+  height: auto;
+  min-height: 100%;
+}
+
+.se {
+  position: relative;
+  display: flex;
+  flex-direction: row;
+  box-sizing: border-box;
+  margin: 0;
+  padding: 0;
+  border-width: 0;
+  border-style: solid;
+  font: inherit;
+}
+
+.se.above {
+  position: absolute;
+  display: block;
+  top: 0;
+  height: 0;
+  z-index: 10;
+}
+
+.se.above > .height-fill {
+  height: auto;
+}
+
+.se.below {
+  position: absolute;
+  display: block;
+  bottom: 0;
+  height: 0;
+  z-index: 10;
+}
+
+.se.below > .height-fill {
+  height: auto;
+}
+
+.se.bold {
+  font-weight: 700;
+}
+
+.se.border-dashed {
+  border-style: dashed;
+}
+
+.se.border-dotted {
+  border-style: dotted;
+}
+
+.se.border-none {
+  border-width: 0;
+}
+
+.se.border-solid {
+  border-style: solid;
+}
+
+.se.italic {
+  font-style: italic;
+}
+
+.se.on-left {
+  position: absolute;
+  display: block;
+  right: 100%;
+  width: 0;
+  z-index: 10;
+}
+
+.se.on-right {
+  position: absolute;
+  display: block;
+  left: 100%;
+  width: 0;
+  z-index: 10;
+}
+
+.se.overlay {
+  position: absolute;
+  display: block;
+  left: 0;
+  top: 0;
+  z-index: 10;
+}
+
+.se.strike {
+  text-decoration: line-through;
+}
+
+.se.text-center {
+  text-align: center;
+}
+
+.se.text-justify {
+  text-align: justify;
+}
+
+.se.text-justify-all {
+  text-align: justify-all;
+}
+
+.se.text-left {
+  text-align: left;
+}
+
+.se.text-light {
+  font-weight: 300;
+}
+
+.se.text-right {
+  text-align: right;
+}
+
+.se.underline {
+  text-decoration: underline;
+}
+
+.se.width-content {
+  width: auto;
+}
+
+.text {
+  white-space: pre;
+  display: inline-block;
+}
+
+.spacer + .se {
+  margin-top: 0;
+  margin-left: 0;
+}
+
+.el {
+  display: flex;
+  flex-direction: row;
+}
+
+.el > .height-fill {
+  height: 100%;
+}
+
+.el > .se.self-bottom {
+  align-self: flex-end;
+}
+
+.el > .se.self-center-x {
+  margin-left: auto;
+  margin-right: auto;
+}
+
+.el > .se.self-center-y {
+  align-self: center;
+}
+
+.el > .se.self-left {
+  margin-right: auto;
+}
+
+.el > .se.self-right {
+  margin-left: auto;
+}
+
+.el > .se.self-top {
+  align-self: flex-start;
+}
+
+.el > .width-fill {
+  width: 100%;
+}
+
+.el.content-bottom {
+  align-items: flex-end;
+}
+
+.el.content-center-x {
+  justify-content: center;
+}
+
+.el.content-center-y {
+  align-items: center;
+}
+
+.el.content-left {
+  justify-content: flex-start;
+}
+
+.el.content-right {
+  justify-content: flex-end;
+}
+
+.el.content-top {
+  align-items: flex-start;
+}
+
+.nearby {
+  position: absolute;
+  width: 100%;
+  height: 100%;
+  pointer-events: none;
+}
+
+.row {
+  display: flex;
+  flex-direction: row;
+}
+
+.row > .height-fill {
+  height: 100%;
+}
+
+.row > .se.self-bottom {
+  align-self: flex-end;
+}
+
+.row > .se.self-center-y {
+  align-self: center;
+}
+
+.row > .se.self-top {
+  align-self: flex-start;
+}
+
+.row > .width-fill {
+  flex-grow: 1;
+}
+
+.row.content-bottom {
+  align-items: flex-end;
+}
+
+.row.content-center-x {
+  justify-content: center;
+}
+
+.row.content-center-y {
+  align-items: center;
+}
+
+.row.content-left {
+  justify-content: flex-start;
+}
+
+.row.content-right {
+  justify-content: flex-end;
+}
+
+.row.content-top {
+  align-items: flex-start;
+}
+
+.row.space-evenly {
+  justify-content: space-between;
+}
+
+.column {
+  display: flex;
+  flex-direction: column;
+}
+
+.column > .height-fill {
+  flex-grow: 1;
+}
+
+.column > .se.self-center-x {
+  align-self: center;
+}
+
+.column > .se.self-left {
+  align-self: flex-start;
+}
+
+.column > .se.self-right {
+  align-self: flex-end;
+}
+
+.column > .width-fill {
+  width: 100%;
+}
+
+.column.content-bottom {
+  justify-content: flex-end;
+}
+
+.column.content-center-x {
+  align-items: center;
+}
+
+.column.content-center-y {
+  justify-content: center;
+}
+
+.column.content-left {
+  align-items: flex-start;
+}
+
+.column.content-right {
+  align-items: flex-end;
+}
+
+.column.content-top {
+  justify-content: flex-start;
+}
+
+.page {
+  display: block;
+}
+
+.page > .se.self-left {
+  float: left;
+}
+
+.page > .se.self-left:after: {
+  content: "";
+  display: table;
+  clear: both;
+}
+
+.page > .se.self-left:first-child + .se {
+  margin: 0 !important;
+}
+
+.page > .se.self-right {
+  float: right;
+}
+
+.page > .se.self-right:after: {
+  content: "";
+  display: table;
+  clear: both;
+}
+
+.page > .se.self-right:first-child + .se {
+  margin: 0 !important;
+}
+
+.paragraph {
+  display: block;
+}
+
+.paragraph > .column {
+  display: inline-flex;
+}
+
+.paragraph > .el {
+  display: inline-flex;
+}
+
+.paragraph > .el > .text {
+  display: inline;
+  white-space: normal;
+}
+
+.paragraph > .grid {
+  display: inline-grid;
+}
+
+.paragraph > .row {
+  display: inline-flex;
+}
+
+.paragraph > .se.self-left {
+  float: left;
+}
+
+.paragraph > .se.self-right {
+  float: right;
+}
+
+.paragraph > .text {
+  display: inline;
+  white-space: normal;
+}
+
+.hidden {
+  display: none;
+}
+
+.bg-52-101-164-100{background-color:rgba(52,101,164,1)}
+.text-color-255-255-255-100{color:rgba(255,255,255,1)}
+.font-size-20{font-size:20px}
+.font-opensansgeorgiaserif{font-family:"Open Sans", "georgia", serif}
+""" ]

--- a/elm-ui15:49:52/tests-rendering/cases/resolved/Images/ImageRegression2.elm
+++ b/elm-ui15:49:52/tests-rendering/cases/resolved/Images/ImageRegression2.elm
@@ -1,0 +1,19 @@
+module ImageRegression2 exposing (main)
+
+{-| <https://github.com/mdgriffith/elm-ui/issues/228>
+-}
+
+import Element exposing (..)
+
+
+main =
+    Element.layout []
+        (Element.row [ width fill, height fill, explain Debug.todo ]
+            [ text "BEFORE"
+            , image []
+                { src = "https://placekitten.com/300/200"
+                , description = "kitten"
+                }
+            , text "AFTER"
+            ]
+        )

--- a/src/Player.elm
+++ b/src/Player.elm
@@ -20,6 +20,7 @@ type BPlayerToPlayStatus
     | BPlayerHasDiscard Power
     | BPlayerLookACard LookACardStatus
     | BPlayerSwitch2Cards Switch2CardsStatus
+    | BPlayerDisplayTamalouFailure Counter
 
 
 type alias FPlayer =


### PR DESCRIPTION
Related to #20

Adds a new variant `BPlayerDisplayTamalouFailure Counter` to `BPlayerToPlayStatus` in `src/Player.elm` to handle the display of a player's cards when their tamalou fails. This change aligns with the initial plan to introduce a new state for displaying the failed tamalou attempt, including a counter for the display duration.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/CharlonTank/tamalou-v2/issues/20?shareId=1836305f-f364-4bdc-a2a6-8d6f97f70d25).